### PR TITLE
Fix video recording for non-Oracle JVMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.xsavikx</groupId>
     <artifactId>androidscreencast</artifactId>
-    <version>0.0.18s-SNAPSHOT</version>
+    <version>0.0.19s-SNAPSHOT</version>
     <name>Android Screencast</name>
     <packaging>jar</packaging>
     <properties>

--- a/src/main/java/com/github/xsavikx/androidscreencast/api/injector/ScreenCaptureRunnable.java
+++ b/src/main/java/com/github/xsavikx/androidscreencast/api/injector/ScreenCaptureRunnable.java
@@ -129,10 +129,9 @@ public final class ScreenCaptureRunnable implements Runnable {
         this.listener = listener;
     }
 
-
     public void startRecording(final File file) {
         try {
-            qos = new QuickTimeOutputStream(file, QuickTimeOutputStream.VideoFormat.JPG);
+            qos = new QuickTimeOutputStream(file, QuickTimeOutputStream.VideoFormat.PNG);
             qos.setVideoCompressionQuality(MOV_COMPRESSION_RATE);
             qos.setTimeScale(MOV_FPS);
         } catch (final IOException e) {


### PR DESCRIPTION
This PR fixes video recording while running the app in non-Oracle JVMs.

Non-Oracle JVMs do not support writing JPG frames that have an alpha channel. So from now on, we're using PNG frames to record the video that supports alpha (even if we don't have any).

See https://bugs.openjdk.java.net/browse/JDK-8211748 for details.